### PR TITLE
Rebuild with mysql 8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - cxx-standard-17.patch
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win]
 
 requirements:
@@ -26,7 +26,7 @@ requirements:
   host:
     - cppzmq
     - cpptango
-    - mysql-devel
+    - mysql-devel <9
     - omniorb-libs
 
 test:


### PR DESCRIPTION


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

From MySQL 9.0, `mysql_native_password` is removed from built-in auth methods. It can be built as plugin but isn't currently in the conda-forge package. See https://dev.mysql.com/doc/relnotes/mysql/9.0/en/news-9-0-0.html

With mysql-libs 9, `Databaseds` fails to connect to mariadb with:

```
Databaseds[4039]: Error reason = CANNOT_CONNECT_MYSQL
Databaseds[4039]: Desc : Failed to connect to TANGO database (error = Authentication plugin 'mysql_native_password' cannot be loaded: /opt/conda/envs/tango-db/lib/plugin/mysql_native_password.so: cannot open shared object file
Databaseds[4039]: Origin : DataBase::init_device()
```

Pin mysql-devel to <9 for now.
